### PR TITLE
Ensure supervisor uses frontend dependencies

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,8 @@
 const { spawn } = require('child_process');
 const http = require('http');
+const path = require('path');
+
+module.paths.unshift(path.resolve(__dirname, 'frontend/node_modules'));
 const next = require('next');
 
 const BACKEND_PORT = 8000;


### PR DESCRIPTION
## Summary
- import Node's path module in the supervisor
- prepend the frontend node_modules directory before requiring Next so both runtimes share dependencies

## Testing
- cd frontend && npm install

------
https://chatgpt.com/codex/tasks/task_e_68dc0fb8f9988329aa4cac517b69817b