### PR TITLE
Document Replit deployment build command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ backend/build/
 frontend/.next/
 frontend/.next-dev/
 frontend/node_modules/
+node_modules/
 .env
 backend/.env
 frontend/.env.local

--- a/.replit
+++ b/.replit
@@ -60,5 +60,11 @@ externalPort = 8000
 
 [deployment]
 deploymentTarget = "vm"
+# Build both the backend and the Next.js production bundle. The root
+# `npm run build` script installs dependencies and emits `frontend/.next`
+# so the supervisor can serve the compiled frontend without rebuilding at
+# runtime.
 build = ["npm", "run", "build"]
+# Keep the supervisor entrypoint so it can reuse the freshly built
+# frontend bundle while managing both services.
 run = ["npm", "start"]

--- a/replit.md
+++ b/replit.md
@@ -84,6 +84,14 @@ Preferred communication style: Simple, everyday language.
 - Poetry/pip for Python dependency management
 - Node.js package management with npm
 
+## Deployment Notes
+
+- **Build Command**: `npm run build`
+  - Installs backend and frontend dependencies and produces the `frontend/.next` production bundle that the supervisor reuses during startup.
+- **Start Command**: `npm start`
+  - Runs `node server.js`, launching the supervisor so both backend and frontend processes reuse the freshly built assets.
+- After updating the deployment settings, redeploy to verify the public URL no longer displays the “Internal Server Error” banner and that the chat workflow completes successfully.
+
 **Data Storage**
 - File-based storage for documentation corpus and metadata
 - Pickle serialization for search indexes and embeddings


### PR DESCRIPTION
## Summary
- add deployment notes clarifying that the VM build command should run `npm run build` and the start command remains `npm start`
- document the resulting production bundle expectation and redeployment validation steps in `replit.md`
- annotate the `.replit` deployment configuration for future maintainers and ignore the root `node_modules/` directory

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc10f240388329b00cb5bf9cebd3ad