### PR TITLE
Adjust startup sequencing for backend/frontend

### DIFF
--- a/server.js
+++ b/server.js
@@ -84,8 +84,9 @@ process.on('SIGQUIT', () => handleShutdown('SIGQUIT'));
 
 async function main() {
   try {
-    await startBackend();
+    const backendReady = startBackend();
     await startFrontend();
+    await backendReady;
   } catch (error) {
     console.error('Failed to start services:', error);
     if (backendProcess) {


### PR DESCRIPTION
## Summary
- start the backend asynchronously before awaiting frontend startup so the frontend port opens immediately
- wait for the backend startup to finish after the frontend is listening to catch backend failures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc14f0ff4483299bf1ea4dde934507